### PR TITLE
added role to JWT + separated errors: email vs passwd

### DIFF
--- a/microservices-parent/user-service/src/main/java/org/example/userservice/controller/UserController.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/controller/UserController.java
@@ -29,6 +29,7 @@ public class UserController {
         String jwt = userService.login(loginDTO);
         return ResponseEntity.ok(jwt);
     }
+
     @DeleteMapping("/delete/{id}")
     public ResponseEntity<String> deleteUser(@PathVariable Long id) {
         try {

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/dto/userdto/UserLoginDTO.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/dto/userdto/UserLoginDTO.java
@@ -1,7 +1,5 @@
 package org.example.userservice.dto.userdto;
-
 import lombok.*;
-
 
 @NoArgsConstructor
 @AllArgsConstructor

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/security/SecurityConfig.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/security/SecurityConfig.java
@@ -26,7 +26,6 @@ public class SecurityConfig {
     @Autowired
     private JWTFilter jwtFilter;
 
-
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
@@ -35,7 +34,6 @@ public class SecurityConfig {
                 .requestMatchers("/api/user/login", "/api/user/register").permitAll()
                 .requestMatchers("/api/admin/**").hasRole("Admin")
                 .requestMatchers("/api/tourist/**").hasRole("Tourist")
-
                 .anyRequest().authenticated());
         http.httpBasic(Customizer.withDefaults());
         http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/service/JWTService.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/service/JWTService.java
@@ -4,6 +4,9 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.example.userservice.entity.Users;
+import org.example.userservice.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
@@ -21,7 +24,11 @@ import java.util.function.Function;
 public class JWTService {
     private String secretKey = "";
 
-    public JWTService() {
+    private final UserRepository userRepository;
+
+    @Autowired
+    public JWTService(UserRepository userRepository) {
+        this.userRepository = userRepository;
         try {
             KeyGenerator keyGen = KeyGenerator.getInstance("HmacSHA256");
             SecretKey sk = keyGen.generateKey();
@@ -33,6 +40,11 @@ public class JWTService {
 
     public String generateToken(String email) {
         Map<String, Object> claims = new HashMap<>();
+
+        Users user = userRepository.findUserByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found for JWT"));
+
+        claims.put("role", user.getRole().name()); // trimit rolul ca string
 
         return Jwts.builder()
                 .setClaims(claims)


### PR DESCRIPTION
Changed generateToken() method to include the user's role in the JWT. This allows role-based redirects on the frontend without significant changes of the existing backend logic.

Refactored the login() method to explicitly check if the provided email exists in the database before calling authenticationManager.authenticate(). This allows us to distinguish between:
 →  cases where the email is not registered 
 →  and cases where the email exists but the password is incorrect.
This change enables clearer and more specific error messages to be shown in the user interface.