### PR TITLE
92 93 pass reset

### DIFF
--- a/microservices-parent/user-service/pom.xml
+++ b/microservices-parent/user-service/pom.xml
@@ -82,7 +82,14 @@
             <version>0.12.5</version>
             <scope>runtime</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/controller/UserController.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/controller/UserController.java
@@ -1,7 +1,9 @@
 package org.example.userservice.controller;
 
+import org.example.userservice.dto.userdto.PasswordResetDTO;
 import org.example.userservice.dto.userdto.UserLoginDTO;
 import org.example.userservice.dto.userdto.UserRegisterDTO;
+import org.example.userservice.dto.userdto.EmailDTO;
 import org.example.userservice.errorhandler.UserException;
 import org.example.userservice.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +44,37 @@ public class UserController {
     @RequestMapping("/")
     public String hello() {
         return "hello";
+    }
+
+    @PostMapping("/initiate-password-reset")
+    public ResponseEntity<String> initiatePasswordReset(@RequestBody EmailDTO emailDto) {
+        try {
+            userService.initiatePasswordReset(emailDto.getEmail());
+            return ResponseEntity.ok("Password reset link sent to your email.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+
+    @GetMapping("/validate-password-reset-token")
+    public ResponseEntity<String> validatePasswordResetToken(@RequestParam String token) {
+        try {
+            userService.validatePasswordResetToken(token);
+            return ResponseEntity.ok("Token is valid.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<String> resetPassword(@RequestBody PasswordResetDTO dto) {
+        try {
+            userService.resetPassword(dto.getToken(), dto.getNewPassword());
+            return ResponseEntity.ok("Password has been reset successfully.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 
 

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/dto/userdto/EmailDTO.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/dto/userdto/EmailDTO.java
@@ -1,0 +1,15 @@
+package org.example.userservice.dto.userdto;
+
+public class EmailDTO {
+    private String email;
+
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+}

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/dto/userdto/PasswordResetDTO.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/dto/userdto/PasswordResetDTO.java
@@ -1,0 +1,26 @@
+package org.example.userservice.dto.userdto;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PasswordResetDTO {
+    private String token;
+    private String newPassword;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+}

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/entity/Users.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/entity/Users.java
@@ -3,6 +3,8 @@ package org.example.userservice.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name="Users")
 @NoArgsConstructor
@@ -42,6 +44,12 @@ public class Users {
     )
     private UserRole role;
 
+    @Column(name = "password_reset_token")
+    private String passwordResetToken;
+
+    @Column(name = "token_expiry_date")
+    private LocalDateTime tokenExpiryDate;
+
     public Long getId() {
         return id;
     }
@@ -80,5 +88,21 @@ public class Users {
 
     public void setRole(UserRole role) {
         this.role = role;
+    }
+
+    public String getPasswordResetToken() {
+        return passwordResetToken;
+    }
+
+    public LocalDateTime getTokenExpiryDate() {
+        return tokenExpiryDate;
+    }
+
+    public void setPasswordResetToken(String passwordResetToken) {
+        this.passwordResetToken = passwordResetToken;
+    }
+
+    public void setTokenExpiryDate(LocalDateTime tokenExpiryDate) {
+        this.tokenExpiryDate = tokenExpiryDate;
     }
 }

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/repository/UserRepository.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/repository/UserRepository.java
@@ -11,6 +11,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findUserByEmail(String email);
-
+    Optional<Users> findByPasswordResetToken(String token);
 }
 

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/security/SecurityConfig.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/security/SecurityConfig.java
@@ -28,18 +28,24 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-
         http.csrf(customizer -> customizer.disable());
+        http.cors(Customizer.withDefaults());
         http.authorizeHttpRequests(request -> request
-                .requestMatchers("/api/user/login", "/api/user/register").permitAll()
+                .requestMatchers(
+                        "/api/user/login",
+                        "/api/user/register",
+                        "/api/user/initiate-password-reset",
+                        "/api/user/reset-password",
+                        "/api/user/validate-password-reset-token"
+                ).permitAll()
                 .requestMatchers("/api/admin/**").hasRole("Admin")
                 .requestMatchers("/api/tourist/**").hasRole("Tourist")
-                .anyRequest().authenticated());
+                .anyRequest().authenticated()
+        );
         http.httpBasic(Customizer.withDefaults());
         http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         http.addFilterBefore(jwtFilter , UsernamePasswordAuthenticationFilter.class);
         return http.build();
-
     }
     @Bean
     public AuthenticationProvider authenticationProvider(){

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/service/EmailService.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/service/EmailService.java
@@ -1,0 +1,43 @@
+package org.example.userservice.service;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import java.io.UnsupportedEncodingException;
+
+@Service
+public class EmailService {
+
+    @Autowired
+    private JavaMailSender mailSender;
+
+    public void sendPasswordResetEmail(String toEmail, String token) {
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
+
+            String resetLink = "http://localhost:3000/reset-pass?token=" + token;
+            String htmlMsg = "<p>Hi there!</p>" +
+                    "<p>We received a request to reset your password for your TravelPoints account.</p>" +
+                    "<p>If you made this request, please click the link below to reset your password:</p>" +
+                    "<p><a href=\"" + resetLink + "\">Reset your password</a></p>" +
+                    "<p>If you didn't request a password reset, you can safely ignore this email.</p>" +
+                    "<p>Best regards,<br>TravelPoints Team</p>";
+
+            helper.setText(htmlMsg, true);
+            helper.setTo(toEmail);
+            helper.setSubject("Password Reset Request");
+            helper.setFrom("antonia.rahela@gmail.com", "TravelPoints");
+
+            mailSender.send(mimeMessage);
+
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            throw new RuntimeException("Failed to send email", e);
+        }
+    }
+
+
+}

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/service/EmailService.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/service/EmailService.java
@@ -5,7 +5,6 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-
 import java.io.UnsupportedEncodingException;
 
 @Service
@@ -19,6 +18,7 @@ public class EmailService {
             MimeMessage mimeMessage = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
 
+            //String resetLink = "http://travelpoints.run.place/reset-pass?token=" + token;
             String resetLink = "http://localhost:3000/reset-pass?token=" + token;
             String htmlMsg = "<p>Hi there!</p>" +
                     "<p>We received a request to reset your password for your TravelPoints account.</p>" +

--- a/microservices-parent/user-service/src/main/java/org/example/userservice/service/UserService.java
+++ b/microservices-parent/user-service/src/main/java/org/example/userservice/service/UserService.java
@@ -94,7 +94,7 @@ public class UserService {
         System.out.println("User found for email: " + email);
 
         String token = UUID.randomUUID().toString();
-        LocalDateTime expiryDate = LocalDateTime.now().plusHours(1); // token valid 1h
+        LocalDateTime expiryDate = LocalDateTime.now().plusMinutes(10); // token valid 10 min
         user.setPasswordResetToken(token);
         user.setTokenExpiryDate(expiryDate);
 

--- a/microservices-parent/user-service/src/main/resources/application.properties
+++ b/microservices-parent/user-service/src/main/resources/application.properties
@@ -5,3 +5,13 @@ spring.datasource.password=travelpoints
 spring.jpa.hibernate.ddl-auto=update
 server.address=0.0.0.0
 server.port=8081
+
+# SMTP Gmail Configuration
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=antonia.rahela@gmail.com
+spring.mail.password=rxofsywwzqysmahd
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.default-encoding=UTF-8


### PR DESCRIPTION
For now, the password reset email is configured to use **Gmail SMTP with my personal email address**. This setup is fine for the demo, but later we can replace it with a more professional service if needed.
Also, in the **EmailService**, the reset link currently points to localhost:3000, which was used for local development.
I have added a commented line with the production deployment URL (http://travelpoints.run.place/reset-pass) so it can be easily switched when deploying.